### PR TITLE
Fix incorrect constant name

### DIFF
--- a/helpers/constants.go
+++ b/helpers/constants.go
@@ -43,7 +43,7 @@ const (
 	PPCInstanceReplicationScheme = "ppc_replication_scheme"
 	PPCInstanceProgress          = "ppc_progress"
 	PPCInstanceUserData          = "ppc_user_data"
-	PPCInstancePinPolicy         = "ppc_spn_policy"
+	PPCInstancePinPolicy         = "ppc_pin_policy"
 
 	// IBM PPC Volume
 	PPCVolumeName              = "ppc_volume_name"


### PR DESCRIPTION
Somewhere during refactoring ppc_pin_policy
became ppc_spn_policy which is incorrect and
was causing a bug in the terraform provider.